### PR TITLE
Fix typos within rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ namespace :generate do
   desc "Create an empty model in app/models, e.g., rake generate:model NAME=User"
   task :model do
     unless ENV.has_key?('NAME')
-      raise "Must specificy model name, e.g., rake generate:model NAME=User"
+      raise "Must specify model name, e.g., rake generate:model NAME=User"
     end
 
     model_name     = ENV['NAME'].camelize
@@ -33,7 +33,7 @@ namespace :generate do
   desc "Create an empty migration in db/migrate, e.g., rake generate:migration NAME=create_tasks"
   task :migration do
     unless ENV.has_key?('NAME')
-      raise "Must specificy migration name, e.g., rake generate:migration NAME=create_tasks"
+      raise "Must specify migration name, e.g., rake generate:migration NAME=create_tasks"
     end
 
     name     = ENV['NAME'].camelize
@@ -58,7 +58,7 @@ namespace :generate do
   desc "Create an empty model spec in spec, e.g., rake generate:spec NAME=user"
   task :spec do
     unless ENV.has_key?('NAME')
-      raise "Must specificy migration name, e.g., rake generate:spec NAME=user"
+      raise "Must specify migration name, e.g., rake generate:spec NAME=user"
     end
 
     name     = ENV['NAME'].camelize


### PR DESCRIPTION
Hey thanks for this Sinatra MVC Skeleton! I'm enjoying using it. Hopefully, I can also help a few DBC grads who use this going forward. 
## Synopsis (or why):

Fix a few quick typos I saw while working with the Sinatra MVC Skeleton
## Details (or what):
- change 'specificy' to 'specify"
## Risk (do I think this will this break something?):

No to Low Risk: Only changing string that is generated when an error occurs
